### PR TITLE
Add Java MCP server example for IntelliJ

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This repository collects examples and implementations for the Model Context Protocol (MCP). It is intended as a central place to host different kinds of MCP servers for various projects.
 
 Feel free to contribute server setups, configurations, and documentation as we expand this collection.
+
+## Java MCP Server
+
+A minimal MCP server implemented in Java for easy integration with IntelliJ IDEA. The server code lives in the `java-intellij-server` directory. Follow the instructions there to build and run it.

--- a/java-intellij-server/README.md
+++ b/java-intellij-server/README.md
@@ -1,0 +1,20 @@
+# Java MCP Server
+
+This example demonstrates a minimal MCP server written in Java. The server uses the JDK's built-in HTTP server and exposes a simple `/hello` endpoint.
+
+## Building and Running
+
+```bash
+mvn package
+java -cp target/java-mcp-server-0.1.0.jar com.mcp.server.McpServer
+```
+
+The server listens on port `8080`. You can test it by opening `http://localhost:8080/hello` in your browser or using `curl`.
+
+## Importing into IntelliJ IDEA
+
+1. Open IntelliJ IDEA and choose **Open**.
+2. Select the `java-intellij-server` directory. IntelliJ will automatically detect the Maven project.
+3. Once the project loads, you can run `McpServer` directly from the IDE using the run icon next to the `main` method.
+
+This setup allows you to modify and debug the server inside IntelliJ, making it easy to extend its functionality.

--- a/java-intellij-server/pom.xml
+++ b/java-intellij-server/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mcp</groupId>
+    <artifactId>java-mcp-server</artifactId>
+    <version>0.1.0</version>
+    <packaging>jar</packaging>
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+    </properties>
+</project>

--- a/java-intellij-server/src/main/java/com/mcp/server/McpServer.java
+++ b/java-intellij-server/src/main/java/com/mcp/server/McpServer.java
@@ -1,0 +1,30 @@
+package com.mcp.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+
+public class McpServer {
+    public static void main(String[] args) throws IOException {
+        int port = 8080;
+        HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext("/hello", new HelloHandler());
+        server.setExecutor(null);
+        System.out.println("MCP Java server running on port " + port);
+        server.start();
+    }
+
+    static class HelloHandler implements HttpHandler {
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String response = "Hello from MCP Java server";
+            exchange.sendResponseHeaders(200, response.getBytes().length);
+            try (OutputStream os = exchange.getResponseBody()) {
+                os.write(response.getBytes());
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add minimal MCP server in Java
- document how to load and run the server in IntelliJ IDEA
- update project README with a link to the new example

## Testing
- `mvn -q -DskipTests=true package` *(fails: Plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_6888f47108c88325b3819cd78808aac9