### PR TITLE
Add OpenAI analysis endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Feel free to contribute server setups, configurations, and documentation as we e
 ## Java MCP Server
 
 A minimal MCP server implemented in Java for easy integration with IntelliJ IDEA. The server code lives in the `java-intellij-server` directory. Follow the instructions there to build and run it.
+
+The `basic-mcp-java-server` module now includes an example endpoint that calls the OpenAI API for code analysis.

--- a/basic-mcp-java-server/README.md
+++ b/basic-mcp-java-server/README.md
@@ -8,4 +8,12 @@ Model Context Protocol (MCP) style requests. It exposes two endpoints:
 - `GET /health` returns `OK` to verify the service is running.
 
 The project is structured to allow easy extension for tools, history management,
-and user handling.
+and user handling. A new endpoint demonstrates how to integrate with external
+services like OpenAI for code analysis.
+
+## New `/analyze` Endpoint
+
+`POST /analyze` accepts a JSON payload with a `code` field. The server forwards
+this code to the OpenAI API (if an API key is configured via the
+`openai.api.key` property) and returns the assistant's response. When no API key
+is provided, a placeholder message is returned.

--- a/basic-mcp-java-server/src/main/java/com/example/mcp/controller/AnalysisController.java
+++ b/basic-mcp-java-server/src/main/java/com/example/mcp/controller/AnalysisController.java
@@ -1,0 +1,29 @@
+package com.example.mcp.controller;
+
+import com.example.mcp.dto.CodeRequest;
+import com.example.mcp.service.OpenAiService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Exposes an endpoint to analyze code using OpenAI.
+ */
+@RestController
+@RequestMapping("/analyze")
+public class AnalysisController {
+
+    private final OpenAiService openAiService;
+
+    public AnalysisController(OpenAiService openAiService) {
+        this.openAiService = openAiService;
+    }
+
+    @PostMapping
+    public ResponseEntity<String> analyze(@RequestBody CodeRequest request) {
+        String result = openAiService.analyze(request.getCode());
+        return ResponseEntity.ok(result);
+    }
+}

--- a/basic-mcp-java-server/src/main/java/com/example/mcp/dto/CodeRequest.java
+++ b/basic-mcp-java-server/src/main/java/com/example/mcp/dto/CodeRequest.java
@@ -1,0 +1,16 @@
+package com.example.mcp.dto;
+
+/**
+ * Request payload for code analysis.
+ */
+public class CodeRequest {
+    private String code;
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/basic-mcp-java-server/src/main/java/com/example/mcp/service/OpenAiService.java
+++ b/basic-mcp-java-server/src/main/java/com/example/mcp/service/OpenAiService.java
@@ -1,0 +1,63 @@
+package com.example.mcp.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * Service that calls the OpenAI API to analyze code.
+ * This is a minimal example and does not cover error handling.
+ */
+@Service
+public class OpenAiService {
+
+    @Value("${openai.api.key:}")
+    private String apiKey;
+
+    private final RestTemplate restTemplate = new RestTemplate();
+
+    public String analyze(String code) {
+        if (apiKey == null || apiKey.isBlank()) {
+            return "OpenAI API key not configured";
+        }
+
+        String url = "https://api.openai.com/v1/chat/completions";
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(apiKey);
+
+        Map<String, Object> payload = new HashMap<>();
+        payload.put("model", "gpt-3.5-turbo");
+        payload.put("messages", new Object[] {
+                Map.of("role", "system", "content", "You are a code analysis assistant."),
+                Map.of("role", "user", "content", code)
+        });
+
+        HttpEntity<Map<String, Object>> request = new HttpEntity<>(payload, headers);
+
+        Map<?, ?> response = restTemplate.postForObject(url, request, Map.class);
+        if (response == null) {
+            return "No response from OpenAI";
+        }
+        Object choices = response.get("choices");
+        if (choices instanceof java.util.List<?> list && !list.isEmpty()) {
+            Object first = list.get(0);
+            if (first instanceof Map<?, ?> choice) {
+                Object message = choice.get("message");
+                if (message instanceof Map<?, ?> msg) {
+                    Object content = msg.get("content");
+                    if (content != null) {
+                        return content.toString();
+                    }
+                }
+            }
+        }
+        return "Unable to parse OpenAI response";
+    }
+}


### PR DESCRIPTION
## Summary
- implement `OpenAiService` to call OpenAI's API
- add `AnalysisController` with a `/analyze` endpoint
- define `CodeRequest` DTO
- document new endpoint in README files

## Testing
- `mvn package` *(fails: `maven-resources-plugin` could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_b_68890e693798832582da23f09b28b394